### PR TITLE
Fix for getting started instructions

### DIFF
--- a/cloudworkstations/README.md
+++ b/cloudworkstations/README.md
@@ -20,18 +20,18 @@ Installation of the following packages are needed before building:
 ```bash
 mkdir ./backstage-local-plugins-install
 cd ./backstage-local-plugins-install
-git clone git@github.com:GoogleCloudPlatform/platform-engineering.git
+git clone git@github.com:GoogleCloudPlatform/google-cloud-backstage-plugins.git
 ```
 
 ### Build the plugin
 
 ```bash
-cd ./platform-engineering/google-cloud-backstage-plugins/cloudworkstations
+cd ./google-cloud-backstage-plugins/cloudworkstations
 yarn install
 yarn clean
 yarn tsc
 yarn build
-rm -rf node_modules (avoid overriding the peer deps)
+rm -rf node_modules # (avoid overriding the peer deps)
 ```
 
 ### Go to the backstage app local directory and install the plugin

--- a/cloudworkstations/package.json
+++ b/cloudworkstations/package.json
@@ -1,19 +1,3 @@
-/**
- * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */ 
-
 {
   "name": "@googlecloud-backstage-plugins/cloudworkstations",
   "description": "A plugin that integrates Google Cloud Workstations with Backstage.",

--- a/cloudworkstations/tsconfig.json
+++ b/cloudworkstations/tsconfig.json
@@ -1,20 +1,4 @@
-/**
- * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */ 
-
-{
+ {
   "extends": "@backstage/cli/config/tsconfig.json",
   "include": [
     "src",


### PR DESCRIPTION
* JSON files contained license headers and broke YARN
  * These files are do not require a license header as per Google OS standards
  * Consider using the [AddLicense](https://github.com/google/addlicense) tool to automate adding license headers where required.

* Legacy repo name `platform-engineering` was still present in README.md